### PR TITLE
Update to use latest firrtl foreachStmt instead of map

### DIFF
--- a/src/main/scala/dotvisualizer/transforms/ModuleLevelDiagrammer.scala
+++ b/src/main/scala/dotvisualizer/transforms/ModuleLevelDiagrammer.scala
@@ -126,7 +126,7 @@ class ModuleLevelDiagrammer extends Transform {
       c.modules.find(m => m.name == instance.module) match {
         case Some(module) =>
           val set = new mutable.HashSet[WDefInstance]
-          module map InstanceGraph.collectInstances(set)
+          module foreachStmt InstanceGraph.collectInstances(set)
           set.toSet
 
         case None => Set.empty[WDefInstance]


### PR DESCRIPTION
- Project had not been updated to use foreachStmt for pass that did not update things.
- Would have been caught if we had some form of CI for this repo.