### PR TITLE
New option to allow different layout ranking

### DIFF
--- a/src/main/scala/dotvisualizer/FirrtlDiagrammer.scala
+++ b/src/main/scala/dotvisualizer/FirrtlDiagrammer.scala
@@ -40,6 +40,8 @@ case class SetOpenProgram(openProgram: String) extends OptionAnnotation
 
 case class DotTimeOut(seconds: Int) extends OptionAnnotation
 
+case object UseRankAnnotation extends OptionAnnotation
+
 object FirrtlDiagrammer {
 
   var dotTimeOut = 7
@@ -184,7 +186,7 @@ object FirrtlDiagrammer {
       transform.execute(circuitState)
     }
 
-    val fileName = s"${targetDir}${circuitState.circuit.main}_hierarchy.dot"
+    val fileName = s"$targetDir${circuitState.circuit.main}_hierarchy.dot"
     val openProgram = controlAnnotations.collectFirst {
       case SetOpenProgram(program) => program
     }.getOrElse("open")
@@ -217,6 +219,10 @@ object FirrtlDiagrammer {
               .action { (_, c) => c.copy(justTopLevel = true) }
               .text("use this to only see the top level view")
 
+      opt[Unit]('j', "rank-elements")
+              .action { (_, c) => c.copy(useRanking = true) }
+              .text("tries to rank elements by depth from inputs")
+
       opt[Int]('s', "dot-timeout-seconds")
               .action { (x, c) => c.copy(dotTimeOut = x) }
               .text("use this to only see the top level view")
@@ -238,7 +244,8 @@ case class Config(
   openProgram:      String = Config.getOpenForOs,
   targetDir:        String = "",
   justTopLevel:     Boolean = false,
-  dotTimeOut:       Int     = 7
+  dotTimeOut:       Int     = 7,
+  useRanking:       Boolean = false
 ) {
   def toAnnotations: Seq[Annotation] = {
     val dir = {
@@ -256,7 +263,8 @@ case class Config(
       TargetDirAnnotation(dir),
       DotTimeOut(dotTimeOut)
     ) ++
-    (if(startModuleName.nonEmpty) Seq(StartModule(startModuleName)) else Seq.empty)
+    (if(startModuleName.nonEmpty) Seq(StartModule(startModuleName)) else Seq.empty) ++
+    (if(useRanking) Seq(UseRankAnnotation) else Seq.empty)
   }
 }
 

--- a/src/main/scala/dotvisualizer/FirrtlDiagrammer.scala
+++ b/src/main/scala/dotvisualizer/FirrtlDiagrammer.scala
@@ -4,9 +4,7 @@ package dotvisualizer
 
 import java.io.{File, PrintWriter}
 
-import chisel3.experimental
-import chisel3.experimental.{ChiselAnnotation, RunFirrtlTransform}
-import chisel3.internal.InstanceId
+import chisel3.experimental.ChiselAnnotation
 import dotvisualizer.transforms.{MakeDiagramGroup, ModuleLevelDiagrammer}
 import firrtl._
 import firrtl.annotations._
@@ -15,10 +13,6 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future, TimeoutException, blocking}
 import scala.sys.process._
-
-//TODO: MONICA: Implement depth
-//TODO: Make input and output separate colors
-//TODO: Make modules at different levels separate colors
 
 //scalastyle:off magic.number
 //scalastyle:off regex
@@ -39,6 +33,8 @@ case class SetRenderProgram(renderProgram: String = "dot") extends OptionAnnotat
 case class SetOpenProgram(openProgram: String) extends OptionAnnotation
 
 case class DotTimeOut(seconds: Int) extends OptionAnnotation
+
+case class RankDirAnnotation(rankDir: String) extends OptionAnnotation
 
 case object UseRankAnnotation extends OptionAnnotation
 
@@ -219,6 +215,10 @@ object FirrtlDiagrammer {
               .action { (_, c) => c.copy(justTopLevel = true) }
               .text("use this to only see the top level view")
 
+      opt[String]('o', "rank-dir")
+              .action { (x, c) => c.copy(rankDir = x) }
+              .text("use to set ranking direction, default is LR, TB is good alternative")
+
       opt[Unit]('j', "rank-elements")
               .action { (_, c) => c.copy(useRanking = true) }
               .text("tries to rank elements by depth from inputs")
@@ -245,7 +245,8 @@ case class Config(
   targetDir:        String = "",
   justTopLevel:     Boolean = false,
   dotTimeOut:       Int     = 7,
-  useRanking:       Boolean = false
+  useRanking:       Boolean = false,
+  rankDir:          String  = "LR"
 ) {
   def toAnnotations: Seq[Annotation] = {
     val dir = {
@@ -261,7 +262,8 @@ case class Config(
       SetRenderProgram(renderProgram),
       SetOpenProgram(openProgram),
       TargetDirAnnotation(dir),
-      DotTimeOut(dotTimeOut)
+      DotTimeOut(dotTimeOut),
+      RankDirAnnotation(rankDir)
     ) ++
     (if(startModuleName.nonEmpty) Seq(StartModule(startModuleName)) else Seq.empty) ++
     (if(useRanking) Seq(UseRankAnnotation) else Seq.empty)

--- a/src/main/scala/dotvisualizer/dotnodes/ModuleNode.scala
+++ b/src/main/scala/dotvisualizer/dotnodes/ModuleNode.scala
@@ -37,8 +37,6 @@ case class ModuleNode(
     val inputNames = children.collect { case p: PortNode if p.isInput => p }.map(_.absoluteName)
     val outputPorts = children.collect { case p: PortNode if ! p.isInput => p }.map(_.absoluteName)
 
-//    val sortedSubmodules = subModuleNames.toSeq.sorted.reverse
-
     val diGraph = {
       val linkedHashMap = new mutable.LinkedHashMap[String, mutable.LinkedHashSet[String]] {
         override def default(key: String): mutable.LinkedHashSet[String] = {
@@ -47,31 +45,11 @@ case class ModuleNode(
         }
       }
 
-//      def mapToSubmoduleContainer(componentName: String): String = {
-//        sortedSubmodules.find { subModuleName =>
-//          componentName.take(subModuleName.length) == subModuleName
-//        } match {
-//          case Some(_) => ""
-//          case _ => componentName
-//        }
-//      }
-
       val connectionTargetNames = connections.values.map(_.split(":").head).toSet
 
       connections.foreach { case (rhs, lhs) =>
         val source = lhs.split(":").head
         val target = rhs.split(":").head
-//        val target = namedNodes.get(rhs) match {
-//          case Some(node) if node.isInstanceOf[PortNode] =>
-//            node.parentOpt match {
-//              case Some(parent) =>
-//                mapToSubmoduleContainer(parent.absoluteName)
-//              case _ =>
-//                mapToSubmoduleContainer(rhs.split(":").head)
-//            }
-//          case _ =>
-//            mapToSubmoduleContainer(rhs.split(":").head)
-//        }
 
         if(target.nonEmpty && connectionTargetNames.contains(target)) {
           linkedHashMap(source) += target
@@ -114,7 +92,10 @@ case class ModuleNode(
     rankInfo + "\n  " + s"""{ rank=same; ${outputPorts.mkString(" ")} };"""
   }
 
-  //scalastyle:off method.length
+  /**
+    * Renders this node
+    * @return
+    */
   def render: String = {
     def expandBiConnects(target: String, sources: ArrayBuffer[String]): String = {
       sources.map { vv => s"""$vv -> $target [dir = "both"]"""  }.mkString("\n")

--- a/src/main/scala/dotvisualizer/transforms/MakeOneDiagram.scala
+++ b/src/main/scala/dotvisualizer/transforms/MakeOneDiagram.scala
@@ -374,14 +374,12 @@ class MakeOneDiagram extends Transform {
         pl(s"digraph ${topModule.name} {")
         pl(s"""stylesheet = "styles.css"""")
         pl(s"""rankdir="$rankDir" """)
-        //        pl(s"graph [splines=ortho];")
+        //TODO: make this an option -- pl(s"graph [splines=ortho];")
         val topModuleNode = ModuleNode(startModuleName, parentOpt = None)
         if(useRanking) topModuleNode.renderWithRank = true
         processModule("", topModule, topModuleNode, Scope(0, 1))
-        //        processModule("", topModule, topModuleNode, getScope(topModule.name))
 
         pl(topModuleNode.render)
-        //pl("\"Modules Only View Here\" [URL=\"TopLevel.dot.svg\" shape=\"rectangle\"]; \n")
 
         pl("}")
       case _ =>

--- a/src/test/scala/dotvisualizer/FirExample.scala
+++ b/src/test/scala/dotvisualizer/FirExample.scala
@@ -24,7 +24,9 @@ class FirExampleSpec extends FreeSpec with Matchers {
   """This is an example of an FIR circuit which has a lot of elements in a single module""" in {
     val circuit = chisel3.Driver.elaborate(() => new MyManyDynamicElementVecFir(10))
     val firrtl = chisel3.Driver.emit(circuit)
-    val config = Config(targetDir = "test_run_dir/fir_example/", firrtlSource = firrtl)
+    val config = Config(
+      targetDir = "test_run_dir/fir_example/", firrtlSource = firrtl, rankDir = "TB", useRanking = true
+    )
     FirrtlDiagrammer.run(config)
   }
 }

--- a/src/test/scala/dotvisualizer/GCD.scala
+++ b/src/test/scala/dotvisualizer/GCD.scala
@@ -30,7 +30,7 @@ class GCDTester extends FreeSpec with Matchers {
   "GCD circuit to visualize" in {
     val circuit = chisel3.Driver.elaborate(() => new GCD)
     val firrtl = chisel3.Driver.emit(circuit)
-    val config = Config(targetDir = "test_run_dir/gcd/", firrtlSource = firrtl)
+    val config = Config(targetDir = "test_run_dir/gcd/", firrtlSource = firrtl, useRanking = true)
     FirrtlDiagrammer.run(config)
   }
 }

--- a/src/test/scala/dotvisualizer/HierarchicalModulesExample.scala
+++ b/src/test/scala/dotvisualizer/HierarchicalModulesExample.scala
@@ -100,7 +100,7 @@ class HierarchicalModulesExample extends FreeSpec with Matchers {
   """This is an example of a module with hierarchical submodules """  in {
     val circuit = chisel3.Driver.elaborate(() => new TopOfVisualizer)
     val firrtl = chisel3.Driver.emit(circuit)
-    val config = Config(targetDir = "test_run_dir/visualizer/", firrtlSource = firrtl)
+    val config = Config(targetDir = "test_run_dir/visualizer/", firrtlSource = firrtl, useRanking = true)
     FirrtlDiagrammer.run(config)
   }
 }

--- a/src/test/scala/dotvisualizer/HierarchicalModulesExample.scala
+++ b/src/test/scala/dotvisualizer/HierarchicalModulesExample.scala
@@ -100,7 +100,7 @@ class HierarchicalModulesExample extends FreeSpec with Matchers {
   """This is an example of a module with hierarchical submodules """  in {
     val circuit = chisel3.Driver.elaborate(() => new TopOfVisualizer)
     val firrtl = chisel3.Driver.emit(circuit)
-    val config = Config(targetDir = "test_run_dir/visualizer/", firrtlSource = firrtl, useRanking = true)
+    val config = Config(targetDir = "test_run_dir/visualizer/", firrtlSource = firrtl)
     FirrtlDiagrammer.run(config)
   }
 }


### PR DESCRIPTION
This new option, controlled by the useRank option, directs `dot` to arrange the graph in loose columns or rows based on their connection depth from the top-level inputs. Sometimes this looks a lot better, sometimes not. Added based on things learned while adding DiGraph rendering to Firrtl.