### PR TITLE
Bump to 1.1-SNAPSHOT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases")
 )
 organization := "edu.berkeley.cs"
-version := "1.0-SNAPSHOT"
+version := "1.1-SNAPSHOT"
 autoAPIMappings := true
 scalaVersion := "2.12.7"
 crossScalaVersions := Seq("2.12.7", "2.11.12")

--- a/build.sc
+++ b/build.sc
@@ -13,7 +13,7 @@ trait CrossUnRootedSbtModule extends CrossSbtModule {
 }
 
 trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
-  def publishVersion = "1.0-SNAPSHOT"
+  def publishVersion = "1.1-SNAPSHOT"
 
   def pomSettings = PomSettings(
     description = artifactName(),


### PR DESCRIPTION
This is an attempt to reduce potential confusion over external dependencies. Hopefully it won't have the opposite effect.

`diagrammer` is largely chisel version agnostic (which is good), but in order to support reproducible builds, we need to be specific about which version of chisel we're dependent on.

`diagrammer` 1.0-SNAPSHOTS will be built against chisel 3.1-SNAPSHOTS (the `diagrammer` `1.0.x` branch.
`diagrammer` 1.1-SNAPSHOTS will be built against chisel 3.2-SNAPSHOTS (the `diagrammer` `master` branch).

The only changes to `diagrammer` are in its `build.sbt` and `build.sc`.