### PR TITLE
(maybe) fix compile failed in mill 0.5.1:

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -67,6 +67,10 @@ object diagrammer extends Cross[DiagrammerModule](crossVersions: _*) {
   def docJar = T{
     diagrammer(crossVersions.head).docJar()
   }
+
+  def assembly = T{
+    diagrammer(crossVersions.head).assembly()
+  }
 }
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.

--- a/build.sc
+++ b/build.sc
@@ -44,7 +44,7 @@ val crossVersions = Seq("2.12.7", "2.11.12")
 
 // Make this available to external tools.
 object diagrammer extends Cross[DiagrammerModule](crossVersions: _*) {
-  def defaultVersion(ev: Evaluator[Any]) = T.command{
+  def defaultVersion(ev: Evaluator) = T.command{
     println(crossVersions.head)
   }
 

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,6 @@
 # TODO: make this single file and add maven version
 
 # test success in mill 0.5.1 
-mill "diagrammer[2.12.7].assembly"
-cp out/diagrammer/2.12.7/assembly/dest/out.jar diagrammer.jar
+mill diagrammer.assembly
+find -wholename "*assembly/dest/out.jar" -exec cp {} ./diagrammer.jar \; 
 echo "./firrtl-diagrammer is ready to run"

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 # Proof-of-concept mill build that can be used with ammonite.
 # TODO: make this single file and add maven version
 
-mill diagrammer.assembly
-cp out/diagrammer/assembly/dest/out.jar diagrammer.jar
+# test success in mill 0.5.1 
+mill "diagrammer[2.12.7].assembly"
+cp out/diagrammer/2.12.7/assembly/dest/out.jar diagrammer.jar
 echo "./firrtl-diagrammer is ready to run"


### PR DESCRIPTION
current master version will compile failed by
"mill.eval.Evaluator does not take type parameters"
This change `Evaluator[Any]` to `Evaluator`
and explicitly give the `crossVersion` in `build.sh`
need @edwardcwang to review.