### PR TITLE
fixed bad html characters from appearing in printf port names

### DIFF
--- a/src/main/scala/dotvisualizer/dotnodes/PrintfNode.scala
+++ b/src/main/scala/dotvisualizer/dotnodes/PrintfNode.scala
@@ -42,7 +42,7 @@ case class PrintfArgument(name: String, override val absoluteName: String, conne
   val parentOpt : Option[DotNode] = None // doesn't need to know parent
   def render: String = {
     s"""
-      |<TR><TD PORT="$name">$name</TD></TR>
+      |<TR><TD PORT="$connectTarget">$name</TD></TR>
     """.stripMargin
   }
 }

--- a/src/main/scala/dotvisualizer/transforms/MakeOneDiagram.scala
+++ b/src/main/scala/dotvisualizer/transforms/MakeOneDiagram.scala
@@ -286,14 +286,20 @@ class MakeOneDiagram extends Transform {
         val printfNode = PrintfNode(nodeName, printf.string.serialize, Some(moduleNode))
 
         printf.args.foreach { arg =>
-          val displayName = arg.serialize
-          val connectTarget = s"${printfNode.absoluteName}:$displayName"
-          val processedARg = processExpression(arg)
 
-          val port = printfNode.addArgument(displayName, connectTarget, processedARg)
+          val displayName = arg.serialize
+            .replaceAll("[<]", "&lt;")
+            .replaceAll("[>]", "&gt;")
+            .replaceAll("[(]", "&#40;")
+            .replaceAll("[)]", "&#41;")
+          val connectCode = s"${displayName.hashCode.abs}"
+          val connectTarget = s"${printfNode.absoluteName}:$connectCode"
+          val processedArg = processExpression(arg)
+
+          val port = printfNode.addArgument(displayName, connectCode, processedArg)
           nameToNode(connectTarget) = port
 
-          moduleNode.connect(connectTarget, processedARg)
+          moduleNode.connect(connectTarget, processedArg)
         }
         printfNode.finish()
 


### PR DESCRIPTION
- use a simple number as cell reference for printf port name
- escape to html parens and angle brackets in port display names