### PR TITLE
Allow assembly builds in diagrammer

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -84,8 +84,8 @@ val defaultVersions = Map(
   "chisel3" -> "3.2-SNAPSHOT"
 )
 
-libraryDependencies ++= (Seq("chisel3").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
+libraryDependencies ++= Seq("chisel3").map {
+  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
@@ -96,3 +96,13 @@ libraryDependencies ++= Seq(
 scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
 
 javacOptions ++= javacOptionsVersion(scalaVersion.value)
+
+
+// Assembly
+
+assemblyJarName in assembly := "diagrammer.jar"
+
+test in assembly := {} // Should there be tests?
+
+assemblyOutputPath in assembly := file("./utils/bin/diagrammer.jar")
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 logLevel := Level.Warn
+
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")

--- a/utils/bin/diagrammer
+++ b/utils/bin/diagrammer
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# This may be a brittle way to find $(root_dir)/utils/bin, is there a better way?
+path=`dirname "$0"`
+cmd="java -cp ${path}/diagrammer.jar dotvisualizer.FirrtlDiagrammer ${@:1}"
+eval $cmd


### PR DESCRIPTION
- Add assembly plug-in
- Add assembly section to sbt
- Add diagrammer script to utils/bin

If you want a fast acting diagrammer that's in your path.
copy
utils/bin/diagrammer
utils/bin/diagrammer.jar

to a bin directory that's in your PATH