### PR TITLE
Add support for 2.13, remove support for 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,7 +63,6 @@ libraryDependencies ++= Seq("chisel3").map { dep: String =>
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.9" % "test",
-//  "com.github.scopt" %% "scopt" % "3.7.1"
 )
 
 scalacOptions in Compile ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -9,35 +9,8 @@ resolvers ++= Seq(
 organization := "edu.berkeley.cs"
 version := "1.5-SNAPSHOT"
 autoAPIMappings := true
-scalaVersion := "2.12.10"
-crossScalaVersions := Seq("2.12.10", "2.11.12")
-scalacOptions := Seq("-deprecation", "-feature") ++ scalacOptionsVersion(scalaVersion.value)
-
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
-
-def javacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // Scala 2.12 requires Java 8. We continue to generate
-    //  Java 7 compatible code for Scala 2.11
-    //  for compatibility with old clients.
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
-        Seq("-source", "1.7", "-target", "1.7")
-      case _ =>
-        Seq("-source", "1.8", "-target", "1.8")
-    }
-  }
-}
+scalaVersion := "2.12.14"
+crossScalaVersions := Seq("2.12.15", "2.13.6")
 
 publishMavenStyle := true
 publishArtifact in Test := false
@@ -89,14 +62,20 @@ libraryDependencies ++= Seq("chisel3").map { dep: String =>
 }
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.1.3" % "test",
-  "org.scalacheck" %% "scalacheck" % "1.14.3" % "test",
-  "com.github.scopt" %% "scopt" % "3.7.1"
+  "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+//  "com.github.scopt" %% "scopt" % "3.7.1"
 )
 
-scalacOptions ++= scalacOptionsVersion(scalaVersion.value)
+scalacOptions in Compile ++= Seq(
+  "-deprecation",
+  "-feature",
+  "-unchecked",
+  "-language:reflectiveCalls",
+  "-language:existentials",
+  "-language:implicitConversions"
+)
 
-javacOptions ++= javacOptionsVersion(scalaVersion.value)
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 // Assembly
 

--- a/build.sc
+++ b/build.sc
@@ -43,7 +43,7 @@ trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
   override def javacOptions = CommonBuild.javacOptionsVersion(crossScalaVersion)
 }
 
-val crossVersions = Seq("2.12.10", "2.11.12")
+val crossVersions = Seq("2.12.14", "2.13.6")
 
 // Make this available to external tools.
 object diagrammer extends Cross[DiagrammerModule](crossVersions: _*) {

--- a/build.sc
+++ b/build.sc
@@ -43,7 +43,7 @@ trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
   override def javacOptions = CommonBuild.javacOptionsVersion(crossScalaVersion)
 }
 
-val crossVersions = Seq("2.12.14", "2.13.6")
+val crossVersions = Seq("2.12.15", "2.13.6")
 
 // Make this available to external tools.
 object diagrammer extends Cross[DiagrammerModule](crossVersions: _*) {

--- a/src/main/scala/dotvisualizer/dotnodes/ModuleNode.scala
+++ b/src/main/scala/dotvisualizer/dotnodes/ModuleNode.scala
@@ -141,10 +141,7 @@ case class ModuleNode(
   }
 
   def analogConnect(destination: String, source: String, edgeLabel: String = ""): Unit = {
-    if (!analogConnections.contains(destination)) {
-      analogConnections(destination) = new mutable.ArrayBuffer[String]()
-    }
-    analogConnections(destination) += source
+    analogConnections.getOrElseUpdate(destination, new mutable.ArrayBuffer[String]) += source
   }
 
   def +=(childNode: DotNode): Unit = {

--- a/src/main/scala/dotvisualizer/dotnodes/ModuleNode.scala
+++ b/src/main/scala/dotvisualizer/dotnodes/ModuleNode.scala
@@ -5,6 +5,7 @@ package dotvisualizer.dotnodes
 import dotvisualizer.transforms.MakeOneDiagram
 import firrtl.graph.DiGraph
 
+import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
@@ -21,12 +22,9 @@ case class ModuleNode(
   val subModuleNames: mutable.HashSet[String] = new mutable.HashSet[String]()
 
   val connections: mutable.HashMap[String, String] = new mutable.HashMap()
-  private val analogConnections = new mutable.HashMap[String, ArrayBuffer[String]]() {
-    override def default(key: String): ArrayBuffer[String] = {
-      this(key) = new ArrayBuffer[String]()
-      this(key)
-    }
-  }
+
+  private val analogConnections = new mutable.HashMap[String, ArrayBuffer[String]]()
+
   val localConnections: mutable.HashMap[String, String] = new mutable.HashMap()
 
   val backgroundColorIndex: Int = subModuleDepth % MakeOneDiagram.subModuleColorsByDepth.length
@@ -65,6 +63,7 @@ case class ModuleNode(
       val alreadyVisited = new mutable.HashSet[String]()
       val rankNodes = new mutable.ArrayBuffer[Seq[String]]()
 
+      @tailrec
       def walkByRank(nodes: Seq[String], rankNumber: Int = 0): Unit = {
         rankNodes.append(nodes)
 
@@ -142,6 +141,9 @@ case class ModuleNode(
   }
 
   def analogConnect(destination: String, source: String, edgeLabel: String = ""): Unit = {
+    if (!analogConnections.contains(destination)) {
+      analogConnections(destination) = new mutable.ArrayBuffer[String]()
+    }
     analogConnections(destination) += source
   }
 

--- a/src/main/scala/dotvisualizer/dotnodes/PrintfNode.scala
+++ b/src/main/scala/dotvisualizer/dotnodes/PrintfNode.scala
@@ -24,7 +24,7 @@ case class PrintfNode(name: String, formatString: String, parentOpt: Option[DotN
     port
   }
 
-  def finish() {
+  def finish(): Unit = {
     text.append("""
                   |</TABLE>>];
     """.stripMargin)

--- a/src/test/scala/dotvisualizer/PrintfSpec.scala
+++ b/src/test/scala/dotvisualizer/PrintfSpec.scala
@@ -2,19 +2,18 @@
 
 package dotvisualizer
 
-import java.io.{ByteArrayOutputStream, PrintStream}
-
 import chisel3._
-import chisel3.stage.{ChiselGeneratorAnnotation, ChiselStage}
+import chisel3.stage.ChiselGeneratorAnnotation
 import dotvisualizer.stage._
 import firrtl.FileUtils
 import firrtl.annotations.Annotation
 import firrtl.options.TargetDirAnnotation
-import firrtl.stage.FirrtlSourceAnnotation
 import org.scalatest.freespec.AnyFreeSpec
 import org.scalatest.matchers.should.Matchers
 
-class HasPrintf extends MultiIOModule {
+import java.io.{ByteArrayOutputStream, PrintStream}
+
+class HasPrintf extends Module {
   val in = IO(Input(Bool()))
   val out = IO(Output(Bool()))
   out := in


### PR DESCRIPTION
- Simplified build.sbt
  - Updated minor versions of scaa 2.12
  - Got rid of -Xsource
  - removed scalacheck
- build.sc
  - updated versions
- Fixed warning that HashMap will be declared final soon
- Added an type to finish in PrintfNode
- Removed MultiIOModule reference and cleaned imports in PrintfSpec