### PR TITLE
Update master for 1.5.0 release

### DIFF
--- a/.github/configs/mergify_config.yml
+++ b/.github/configs/mergify_config.yml
@@ -1,0 +1,6 @@
+conditions:
+  - status-success=ci
+branches:
+  - 1.2.x
+  - 1.3.x
+  - 1.5.x

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,78 +1,110 @@
+queue_rules:
+- name: default
+  conditions:
+  - status-success=ci
 pull_request_rules:
-  - name: automatic squash-and-merge on CI success and review
-    conditions:
-      - status-success=ci
-      - '#approved-reviews-by>=1'
-      - '#changes-requested-reviews-by=0'
-      - base=master
-      - label="Please Merge"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-  - name: backport to 1.3.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=1.3.x
-    actions:
-      backport:
-        branches:
-          - 1.3.x
-        ignore_conflicts: true
-        label_conflicts: bp-conflict
-      label:
-        add:
-          - Backported
-  - name: backport to 1.2.x, 1.3.x
-    conditions:
-      - merged
-      - base=master
-      - milestone=1.2.x
-    actions:
-      backport:
-        branches:
-          - 1.2.x
-          - 1.3.x
-        ignore_conflicts: true
-        label_conflicts: bp-conflict
-      label:
-        add:
-          - Backported
-  - name: label Mergify backport PR
-    conditions:
-      - body~=This is an automated backport of pull request \#\d+ done by Mergify
-    actions:
-      label:
-        add:
-          - Backport
-  - name: automatic squash-and-mege of 1.2.x backport PRs
-    conditions:
-      - status-success=ci
-      - '#changes-requested-reviews-by=0'
-      - base=1.2.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
-  - name: automatic squash-and-mege of 1.3.x backport PRs
-    conditions:
-      - status-success=ci
-      - '#changes-requested-reviews-by=0'
-      - base=1.3.x
-      - label="Backport"
-      - label!="DO NOT MERGE"
-      - label!="bp-conflict"
-    actions:
-      merge:
-        method: squash
-        strict: smart
-        strict_method: merge
+- name: automatic squash-and-merge on CI success and review
+  conditions:
+  - status-success=ci
+  - '#approved-reviews-by>=1'
+  - '#changes-requested-reviews-by=0'
+  - base=master
+  - label="Please Merge"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
+- name: backport to 1.5.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=1.5.x
+  actions:
+    backport:
+      branches:
+      - 1.5.x
+      labels:
+      - Backport
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: backport to 1.3.x, 1.5.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=1.3.x
+  actions:
+    backport:
+      branches:
+      - 1.3.x
+      - 1.5.x
+      labels:
+      - Backport
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: backport to 1.2.x, 1.3.x, 1.5.x
+  conditions:
+  - merged
+  - base=master
+  - milestone=1.2.x
+  actions:
+    backport:
+      branches:
+      - 1.2.x
+      - 1.3.x
+      - 1.5.x
+      labels:
+      - Backport
+      ignore_conflicts: true
+      label_conflicts: bp-conflict
+    label:
+      add:
+      - Backported
+- name: automatic squash-and-mege of 1.2.x backport PRs
+  conditions:
+  - status-success=ci
+  - '#changes-requested-reviews-by=0'
+  - base=1.2.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
+- name: automatic squash-and-mege of 1.3.x backport PRs
+  conditions:
+  - status-success=ci
+  - '#changes-requested-reviews-by=0'
+  - base=1.3.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
+- name: automatic squash-and-mege of 1.5.x backport PRs
+  conditions:
+  - status-success=ci
+  - '#changes-requested-reviews-by=0'
+  - base=1.5.x
+  - label="Backport"
+  - label!="DO NOT MERGE"
+  - label!="bp-conflict"
+  actions:
+    queue:
+      name: default
+      method: squash
+      update_method: merge
 

--- a/build.sbt
+++ b/build.sbt
@@ -57,9 +57,11 @@ val defaultVersions = Map(
   "chisel3" -> "3.5-SNAPSHOT"
 )
 
-libraryDependencies ++= Seq("chisel3").map { dep: String =>
-  "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
-}
+val chiselVersion = sys.props.getOrElse("chisel3Version", defaultVersions("chisel3"))
+
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % chiselVersion cross CrossVersion.full)
+
+libraryDependencies += "edu.berkeley.cs" %% "chisel3" % chiselVersion
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.9" % "test",


### PR DESCRIPTION
* Enable Mergify for 1.5.x branch

No need to enable CI for 1.5.x branch, this repo only enables CI on PRs and not on push (that could change but I don't feel the need to do it here).

This also updates the mergify configuration to be valid, see https://github.com/chipsalliance/chisel3/pull/2334